### PR TITLE
Refactored index.html to HTML5 validated form

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -170,7 +170,7 @@
 				Back to Finder
 			</a>
 		</div>
-		<div id="external-content" data-role="content"><iframe frameborder="0"></iframe></div>
+		<div id="external-content" data-role="content"><iframe style = "border: 0"></iframe></div>
 	</div>
 	<div id="callout-size-check"></div>
 	<script src="js/nyc/constants.js"></script>


### PR DESCRIPTION
Hello. 

Just a quick PR: index.html was not HTML5 compatible. W3C Validator gave the following error message. 

Line 173, Column 73: The frameborder attribute on the iframe element is obsolete.

I removed the frameborder attribute and replaced it with CSS. 

This file is now HTML5 compatible - did the pre/post change testing, it works as intended after re-factoring. 

Thanks.
